### PR TITLE
Remove i18n entirely from Acuant code

### DIFF
--- a/lib/identity_doc_auth/acuant/config.rb
+++ b/lib/identity_doc_auth/acuant/config.rb
@@ -11,10 +11,7 @@ module IdentityDocAuth
       :assure_id_username,
       :facial_match_url,
       :passlive_url,
-      :friendly_error_message,
-      :friendly_error_find_key,
       :timeout,
-      :i18n,
       :exception_notifier,
       keyword_init: true,
     )

--- a/lib/identity_doc_auth/acuant/request.rb
+++ b/lib/identity_doc_auth/acuant/request.rb
@@ -100,7 +100,7 @@ module IdentityDocAuth
         config.exception_notifier&.call(exception)
         IdentityDocAuth::Response.new(
           success: false,
-          errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
+          errors: { network: true },
           exception: exception,
         )
       end
@@ -109,7 +109,7 @@ module IdentityDocAuth
         config.exception_notifier&.call(exception)
         IdentityDocAuth::Response.new(
           success: false,
-          errors: { network: I18n.t('errors.doc_auth.acuant_network_error') },
+          errors: { network: true },
           exception: exception,
         )
       end

--- a/lib/identity_doc_auth/acuant/responses/facial_match_response.rb
+++ b/lib/identity_doc_auth/acuant/responses/facial_match_response.rb
@@ -18,7 +18,7 @@ module IdentityDocAuth
         def error_messages
           return {} if successful_result?
           {
-            selfie: I18n.t('errors.doc_auth.selfie'),
+            selfie: true,
           }
         end
 

--- a/lib/identity_doc_auth/acuant/responses/liveness_response.rb
+++ b/lib/identity_doc_auth/acuant/responses/liveness_response.rb
@@ -25,7 +25,7 @@ module IdentityDocAuth
         def error_messages
           return {} if successful_result?
           {
-            selfie: I18n.t('errors.doc_auth.selfie'),
+            selfie: true,
           }
         end
 

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/identity_doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/identity_doc_auth/acuant/acuant_client_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
       assure_id_url: assure_id_url,
       facial_match_url: facial_match_url,
       passlive_url: passlive_url,
-      friendly_error_message: proc { 'error' },
-      friendly_error_find_key: proc { 'key' },
     )
   end
 
@@ -185,7 +183,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
       result = subject.create_document
 
       expect(result.success?).to eq(false)
-      expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
+      expect(result.errors).to eq(network: true)
       expect(result.exception.message).to eq(
         'IdentityDocAuth::Acuant::Requests::CreateDocumentRequest Unexpected HTTP response 500',
       )
@@ -200,7 +198,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
       result = subject.create_document
 
       expect(result.success?).to eq(false)
-      expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
+      expect(result.errors).to eq(network: true)
       expect(result.exception.message).to eq(
         'Connection failed',
       )
@@ -251,7 +249,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
+        expect(result.errors).to eq(network: true)
       end
     end
 
@@ -269,7 +267,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+        expect(result.errors).to eq(selfie: true)
       end
     end
 
@@ -287,7 +285,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
         )
 
         expect(result.success?).to eq(false)
-        expect(result.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+        expect(result.errors).to eq(selfie: true)
       end
     end
   end

--- a/spec/identity_doc_auth/acuant/request_spec.rb
+++ b/spec/identity_doc_auth/acuant/request_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
         response = subject.fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
+        expect(response.errors).to eq(network: true)
         expect(response.exception.message).to eq(
           'IdentityDocAuth::Acuant::Request Unexpected HTTP response 404',
         )
@@ -198,7 +198,7 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
         response = subject.fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(network: I18n.t('errors.doc_auth.acuant_network_error'))
+        expect(response.errors).to eq(network: true)
         expect(response.exception).to be_a(Faraday::ConnectionFailed)
       end
     end

--- a/spec/identity_doc_auth/acuant/requests/facial_match_request_spec.rb
+++ b/spec/identity_doc_auth/acuant/requests/facial_match_request_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::FacialMatchRequest do
         ).fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+        expect(response.errors).to eq(selfie: true)
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/identity_doc_auth/acuant/requests/liveness_request_spec.rb
+++ b/spec/identity_doc_auth/acuant/requests/liveness_request_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::LivenessRequest do
         response = request.fetch
 
         expect(response.success?).to eq(false)
-        expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+        expect(response.errors).to eq(selfie: true)
         expect(response.exception).to be_nil
         expect(request_stub).to have_been_requested
       end

--- a/spec/identity_doc_auth/acuant/responses/facial_match_response_spec.rb
+++ b/spec/identity_doc_auth/acuant/responses/facial_match_response_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe IdentityDocAuth::Acuant::Responses::FacialMatchResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+      expect(response.errors).to eq(selfie: true)
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: { selfie: I18n.t('errors.doc_auth.selfie') },
+        errors: { selfie: true },
         exception: nil,
         match_score: 68,
       )

--- a/spec/identity_doc_auth/acuant/responses/liveness_response_spec.rb
+++ b/spec/identity_doc_auth/acuant/responses/liveness_response_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe IdentityDocAuth::Acuant::Responses::LivenessResponse do
       response = described_class.new(http_response)
 
       expect(response.success?).to eq(false)
-      expect(response.errors).to eq(selfie: I18n.t('errors.doc_auth.selfie'))
+      expect(response.errors).to eq(selfie: true)
       expect(response.exception).to be_nil
       expect(response.to_h).to eq(
         success: false,
-        errors: { selfie: I18n.t('errors.doc_auth.selfie') },
+        errors: { selfie: true },
         exception: nil,
         liveness_assessment: nil,
         liveness_score: nil,


### PR DESCRIPTION
**Why**: Allows us to simplify the gem

**How**: Updating the API, will return literal "true" for
values that should be translated with generic errors, and
returning raw untranslated strings for results response

----

If this approach looks good, I'll follow up with similar LexisNexis code