### PR TITLE
LG-3694 Handle unexpected responses from LN TrueID

### DIFF
--- a/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
@@ -89,10 +89,10 @@ module IdentityDocAuth
 
         def products
           @products ||=
-            parsed_response_body.dig(:Products).each_with_object({}) do |product, product_list|
+            parsed_response_body.dig(:Products)&.each_with_object({}) do |product, product_list|
               extract_details(product)
               product_list[product[:ProductType]] = product
-            end.with_indifferent_access
+            end&.with_indifferent_access
         end
 
         def extract_details(product)

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -6,6 +6,7 @@ require 'identity_doc_auth/lexis_nexis/responses/lexis_nexis_response'
 module IdentityDocAuth
   module LexisNexis
     module Responses
+      class LexisNexisResponseError < StandardError; end
       class TrueIdResponse < LexisNexisResponse
         attr_reader :config
 
@@ -18,6 +19,7 @@ module IdentityDocAuth
 
         def successful_result?
           transaction_status_passed? &&
+            true_id_product.present? &&
             product_status_passed? &&
             doc_auth_result_passed?
         end
@@ -25,17 +27,34 @@ module IdentityDocAuth
         def error_messages
           return {} if successful_result?
 
-          ErrorGenerator.new(config).generate_trueid_errors(response_info, @liveness_checking_enabled)
+          if true_id_product.present?
+            ErrorGenerator.new(config).generate_trueid_errors(response_info, @liveness_checking_enabled)
+          else
+            { network: true } # return a generic technical difficulties error to user
+          end
         end
 
         def extra_attributes
-          attrs = response_info.merge(true_id_product[:AUTHENTICATION_RESULT])
-          attrs.reject do |k, _v|
-            PII_DETAILS.include? k
+          if true_id_product.present?
+            attrs = response_info.merge(true_id_product[:AUTHENTICATION_RESULT])
+            attrs.reject do |k, _v|
+              PII_DETAILS.include? k
+            end
+          else
+            response_status = {
+              LN_Status: parsed_response_body[:Status],
+              LN_Info: parsed_response_body.dig(:Information)
+            }
+            e = LexisNexisResponseError.new("Unexpected LN Response: TrueID response not found.")
+
+            config.exception_notifier&.call(e, response_info: response_status)
+            return response_status
           end
         end
 
         def pii_from_doc
+          return {} unless true_id_product.present?
+
           true_id_product[:AUTHENTICATION_RESULT].select do |k, _v|
             PII_DETAILS.include? k
           end
@@ -81,7 +100,7 @@ module IdentityDocAuth
         end
 
         def true_id_product
-          products[:TrueID]
+          products[:TrueID] if products.present?
         end
 
         def parse_alerts

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -42,8 +42,8 @@ module IdentityDocAuth
             end
           else
             response_status = {
-              LN_Status: parsed_response_body[:Status],
-              LN_Info: parsed_response_body.dig(:Information)
+              lexis_nexis_status: parsed_response_body[:Status],
+              lexis_nexis_info: parsed_response_body.dig(:Information)
             }
             e = LexisNexisResponseError.new("Unexpected LN Response: TrueID response not found.")
 

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/fixtures/lexis_nexis_responses/communications_error.json
+++ b/spec/fixtures/lexis_nexis_responses/communications_error.json
@@ -1,0 +1,15 @@
+{
+  "Status": {
+    "ConversationId": "31000473750459",
+    "RequestId": "794609199",
+    "TransactionStatus": "error",
+    "TransactionReasonCode": {"Code": "communications_error", "Description": "Error: Network Communications"},
+    "Reference": "7249e737-0d72-4624-9c8f-ad5832b7d2ba"
+  },
+  "Products": [
+    {
+      "ProductStatus": "error",
+      "ProductReason": {"Code": "communications_error", "Description": "Error: Network Communications"}
+    }
+  ]
+}

--- a/spec/fixtures/lexis_nexis_responses/internal_application_error.json
+++ b/spec/fixtures/lexis_nexis_responses/internal_application_error.json
@@ -1,0 +1,16 @@
+{
+  "Status": {
+    "ConversationId": "31000473747369",
+    "RequestId": "794605589",
+    "TransactionStatus": "error",
+    "TransactionReasonCode": {"Code": "internal_application_error"}
+  },
+  "Information": [
+    {
+      "InformationType": "error-details",
+      "Code": "internal_application_error",
+      "Description": "Error: Internal",
+      "DetailDescription": []
+    }
+  ]
+}

--- a/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
 
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(network: true)
-      expect(output).to include(:LN_Status, :LN_Info)
+      expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
     end
 
     it 'it produces reasonable output for internal application error' do
@@ -107,7 +107,7 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
 
       expect(output[:success]).to eq(false)
       expect(output[:errors]).to eq(network: true)
-      expect(output).to include(:LN_Status, :LN_Info)
+      expect(output).to include(:lexis_nexis_status, :lexis_nexis_info)
     end
   end
 end

--- a/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -20,9 +20,19 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
   let(:failure_response_with_all_failures) do
     instance_double(Faraday::Response, status: 200, body: failure_body_with_all_failures)
   end
+  let(:communications_error_response) do
+    instance_double(Faraday::Response, status: 200, body: LexisNexisFixtures.communications_error)
+  end
+  let(:internal_application_error_response) do
+    instance_double(Faraday::Response, status: 200, body: LexisNexisFixtures.internal_application_error)
+  end
+
+  let(:exception_notifier) { instance_double('Proc') }
 
   let(:config) do
-    IdentityDocAuth::LexisNexis::Config.new
+    IdentityDocAuth::LexisNexis::Config.new(
+      exception_notifier: exception_notifier,
+    )
   end
 
   context 'when the response is a success' do
@@ -74,6 +84,30 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(errors[:general]).to contain_exactly(
         IdentityDocAuth::LexisNexis::Errors::GENERAL_ERROR_LIVENESS,
       )
+    end
+  end
+
+  context 'when response is unexpected' do
+    it 'it produces reasonable output for communications error' do
+      expect(exception_notifier).to receive(:call).
+        with(anything, hash_including(:response_info)).once
+
+      output = described_class.new(communications_error_response, false, config).to_h
+
+      expect(output[:success]).to eq(false)
+      expect(output[:errors]).to eq(network: true)
+      expect(output).to include(:LN_Status, :LN_Info)
+    end
+
+    it 'it produces reasonable output for internal application error' do
+      expect(exception_notifier).to receive(:call).
+        with(anything, hash_including(:response_info)).once
+
+      output = described_class.new(internal_application_error_response, false, config).to_h
+
+      expect(output[:success]).to eq(false)
+      expect(output[:errors]).to eq(network: true)
+      expect(output).to include(:LN_Status, :LN_Info)
     end
   end
 end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -19,6 +19,14 @@ module LexisNexisFixtures
     load_response_fixture('true_id_response_failure_with_all_failures.json')
   end
 
+  def self.communications_error
+    load_response_fixture('communications_error.json')
+  end
+
+  def self.internal_application_error
+    load_response_fixture('internal_application_error.json')
+  end
+
   def self.load_response_fixture(filename)
     path = File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
A few changes to make sure that unexpected responses from LexisNexis TrueID are handled gracefully, logged, and newrelic notified.