### PR TITLE
LG-3694 More failure case handling

### DIFF
--- a/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
@@ -37,13 +37,12 @@ module IdentityDocAuth
         def initialize(http_response)
           @http_response = http_response
 
-          begin
-            super(
-              success: successful_result?,
-              errors: error_messages,
-              extra: extra_attributes,
-              pii_from_doc: pii_from_doc,
-            )
+          super(
+            success: successful_result?,
+            errors: error_messages,
+            extra: extra_attributes,
+            pii_from_doc: pii_from_doc,
+          )
           rescue StandardError => e
             config.exception_notifier&.call(e)
             super(

--- a/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
@@ -43,15 +43,14 @@ module IdentityDocAuth
             extra: extra_attributes,
             pii_from_doc: pii_from_doc,
           )
-          rescue StandardError => e
-            config.exception_notifier&.call(e)
-            super(
-              success: false,
-              errors: { network: true },
-              exception: e,
-              extra: { backtrace: e.backtrace },
-            )
-          end
+        rescue StandardError => e
+          config.exception_notifier&.call(e)
+          super(
+            success: false,
+            errors: { network: true },
+            exception: e,
+            extra: { backtrace: e.backtrace },
+          )
         end
 
         def successful_result?

--- a/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
@@ -36,12 +36,23 @@ module IdentityDocAuth
 
         def initialize(http_response)
           @http_response = http_response
-          super(
-            success: successful_result?,
-            errors: error_messages,
-            extra: extra_attributes,
-            pii_from_doc: pii_from_doc,
-          )
+
+          begin
+            super(
+              success: successful_result?,
+              errors: error_messages,
+              extra: extra_attributes,
+              pii_from_doc: pii_from_doc,
+            )
+          rescue StandardError => e
+            config.exception_notifier&.call(e)
+            super(
+              success: false,
+              errors: { network: true },
+              exception: e,
+              extra: { backtrace: e.backtrace },
+            )
+          end
         end
 
         def successful_result?

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/object/blank'
 require 'identity_doc_auth/lexis_nexis/error_generator'
 require 'identity_doc_auth/lexis_nexis/responses/lexis_nexis_response'
 
@@ -27,7 +28,7 @@ module IdentityDocAuth
         def error_messages
           return {} if successful_result?
 
-          if true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
+          if true_id_product&.dig(:AUTHENTICATION_RESULT).present?
             ErrorGenerator.new(config).generate_trueid_errors(response_info, @liveness_checking_enabled)
           else
             { network: true } # return a generic technical difficulties error to user
@@ -53,7 +54,7 @@ module IdentityDocAuth
         end
 
         def pii_from_doc
-          return {} unless true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
+          return {} unless true_id_product&.dig(:AUTHENTICATION_RESULT).present?
 
           true_id_product[:AUTHENTICATION_RESULT].select do |k, _v|
             PII_DETAILS.include? k

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -27,7 +27,7 @@ module IdentityDocAuth
         def error_messages
           return {} if successful_result?
 
-          if true_id_product.present?
+          if true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
             ErrorGenerator.new(config).generate_trueid_errors(response_info, @liveness_checking_enabled)
           else
             { network: true } # return a generic technical difficulties error to user
@@ -35,7 +35,7 @@ module IdentityDocAuth
         end
 
         def extra_attributes
-          if true_id_product.present?
+          if true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
             attrs = response_info.merge(true_id_product[:AUTHENTICATION_RESULT])
             attrs.reject do |k, _v|
               PII_DETAILS.include? k
@@ -53,7 +53,7 @@ module IdentityDocAuth
         end
 
         def pii_from_doc
-          return {} unless true_id_product.present?
+          return {} unless true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
 
           true_id_product[:AUTHENTICATION_RESULT].select do |k, _v|
             PII_DETAILS.include? k

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/spec/fixtures/lexis_nexis_responses/true_id_response_failure_empty.json
+++ b/spec/fixtures/lexis_nexis_responses/true_id_response_failure_empty.json
@@ -1,0 +1,18 @@
+{
+  "Status": {
+    "ConversationId": "31000476610559",
+    "RequestId": "799094779",
+    "TransactionStatus": "failed",
+    "TransactionReasonCode": {"Code": "failed_true_id"},
+    "Reference": "03830809-3cba-4df4-801a-1734c29a2b7d"
+  },
+  "Products": [
+    {
+      "ProductType": "TrueID",
+      "ExecutedStepName": "True_ID_Step",
+      "ProductConfigurationName": "GSA.V3.TrueID.PM",
+      "ProductStatus": "fail",
+      "ProductReason": {"Code": "failed_true_id"}
+    }
+  ]
+}

--- a/spec/fixtures/lexis_nexis_responses/true_id_response_malformed.json
+++ b/spec/fixtures/lexis_nexis_responses/true_id_response_malformed.json
@@ -1,0 +1,22 @@
+{
+  "Status":    {
+    "ConversationId": "31000175156586",
+    "RequestId": "399948246",
+    "TransactionStatus": "passed",
+    "Reference": "Reference1",
+    "ServerInfo": "server.server.regn.net"
+  },
+  "Products": [   {
+    "ProductType": "TrueID",
+    "ExecutedStepName": "True_ID_Step",
+    "ProductConfigurationName": "TrueID_Flow",
+    "ProductStatus": "pass",
+    "ParameterDetails":       [
+      {
+        "Group": "AUTHENTICATION_RESULT",
+        "Name": "Alert__AlertName",
+        "Values": [{}]
+      }
+    ]
+  }]
+}

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -27,6 +27,14 @@ module LexisNexisFixtures
     load_response_fixture('internal_application_error.json')
   end
 
+  def self.true_id_failure_empty
+    load_response_fixture('true_id_response_failure_empty.json')
+  end
+
+  def self.true_id_response_malformed
+    load_response_fixture('true_id_response_malformed.json')
+  end
+
   def self.load_response_fixture(filename)
     path = File.join(
       File.dirname(__FILE__),


### PR DESCRIPTION
A fix for another couple of cases uncovered by unrelated work. In one I found a way that TrueID could actually send a TrueID formed response that had basically none of the normal data in it.

The other case was a backstop for an exception within the LN Response code. Previously if there was an exception nothing was logged in events.log at all and the details of what exactly had happened were at least partially lost. So I added a rescue to maintain more information.