### PR TITLE
LG-3814 Fixes for LN TrueID failing the doc_pii_form validation check

### DIFF
--- a/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/lexis_nexis_response.rb
@@ -9,29 +9,6 @@ module IdentityDocAuth
   module LexisNexis
     module Responses
       class LexisNexisResponse < IdentityDocAuth::Response
-        PII_DETAILS = %w[
-          Age
-          DocIssuerCode
-          DocIssuerName
-          DocumentName
-          DOB_Day
-          DOB_Month
-          DOB_Year
-          DocIssueType
-          ExpirationDate_Day
-          ExpirationDate_Month
-          ExpirationDate_Year
-          FullName
-          Portrait
-          Sex
-          Fields_Address
-          Fields_AddressLine1
-          Fields_AddressLine2
-          Fields_City
-          Fields_State
-          Fields_PostalCode
-          Fields_Height
-        ].freeze
         attr_reader :http_response
 
         def initialize(http_response)

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -69,7 +69,7 @@ module IdentityDocAuth
         end
 
         def extra_attributes
-          if true_id_product&.dig(:AUTHENTICATION_RESULT).present? && true_id_product[:AUTHENTICATION_RESULT].present?
+          if true_id_product&.dig(:AUTHENTICATION_RESULT).present?
             attrs = response_info.merge(true_id_product[:AUTHENTICATION_RESULT])
             attrs.reject do |k, _v|
               PII_EXCLUDES.include? k
@@ -90,8 +90,8 @@ module IdentityDocAuth
           return {} unless true_id_product&.dig(:IDAUTH_FIELD_DATA).present?
 
           pii = {}
-          PII_INCLUDES.each do |key, value|
-            pii[value] = true_id_product[:IDAUTH_FIELD_DATA][key]
+          PII_INCLUDES.each do |true_id_key, idp_key|
+            pii[idp_key] = true_id_product[:IDAUTH_FIELD_DATA][true_id_key]
           end
 
           pii[:state_id_type] = 'drivers_license'

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -9,6 +9,39 @@ module IdentityDocAuth
     module Responses
       class LexisNexisResponseError < StandardError; end
       class TrueIdResponse < LexisNexisResponse
+        PII_EXCLUDES = %w[
+          Age
+          DocIssuerCode
+          DocIssuerName
+          DocIssue
+          DocumentName
+          DocSize
+          DOB_Day
+          DOB_Month
+          DOB_Year
+          DocIssueType
+          ExpirationDate_Day
+          ExpirationDate_Month
+          ExpirationDate_Year
+          FullName
+          Portrait
+          Sex
+        ].freeze
+
+        PII_INCLUDES = {
+          'Fields_FirstName' => :first_name,
+          'Fields_MiddleName' => :middle_name,
+          'Fields_Surname' => :last_name,
+          'Fields_AddressLine1' => :address1,
+          'Fields_City' => :city,
+          'Fields_State' => :state,
+          'Fields_PostalCode' => :zipcode,
+          'Fields_DOB_Year' => :dob_year,
+          'Fields_DOB_Month' => :dob_month,
+          'Fields_DOB_Day' => :dob_day,
+          'Fields_DocumentNumber' => :state_id_number,
+          'Fields_IssuingStateCode' => :state_id_jurisdiction,
+        }.freeze
         attr_reader :config
 
         def initialize(http_response, liveness_checking_enabled, config)
@@ -36,10 +69,10 @@ module IdentityDocAuth
         end
 
         def extra_attributes
-          if true_id_product.present? && true_id_product[:AUTHENTICATION_RESULT].present?
+          if true_id_product&.dig(:AUTHENTICATION_RESULT).present? && true_id_product[:AUTHENTICATION_RESULT].present?
             attrs = response_info.merge(true_id_product[:AUTHENTICATION_RESULT])
             attrs.reject do |k, _v|
-              PII_DETAILS.include? k
+              PII_EXCLUDES.include? k
             end
           else
             response_status = {
@@ -54,11 +87,16 @@ module IdentityDocAuth
         end
 
         def pii_from_doc
-          return {} unless true_id_product&.dig(:AUTHENTICATION_RESULT).present?
+          return {} unless true_id_product&.dig(:IDAUTH_FIELD_DATA).present?
 
-          true_id_product[:AUTHENTICATION_RESULT].select do |k, _v|
-            PII_DETAILS.include? k
+          pii = {}
+          PII_INCLUDES.each do |key, value|
+            pii[value] = true_id_product[:IDAUTH_FIELD_DATA][key]
           end
+
+          pii[:state_id_type] = 'drivers_license'
+          pii[:dob] = "#{pii[:dob_month]}/#{pii[:dob_day]}/#{pii[:dob_year]}"
+          pii
         end
 
         private

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -53,8 +53,16 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
       expect(extra_attributes).not_to be_empty
     end
     it 'has PII data' do
+      # This is the minimum expected by doc_pii_form in the core IDP
+      minimum_expected_hash = {
+        first_name: 'DAVID',
+        last_name: 'SAMPLE',
+        dob: '10/13/1986',
+        state: 'MD',
+      }
+
       pii_from_doc = described_class.new(success_response, false, config).pii_from_doc
-      expect(pii_from_doc).to include(:first_name, :last_name, :dob, :state)
+      expect(pii_from_doc).to include(minimum_expected_hash)
     end
   end
 

--- a/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
     end
     it 'has PII data' do
       pii_from_doc = described_class.new(success_response, false, config).pii_from_doc
-      expect(pii_from_doc).not_to be_empty
+      expect(pii_from_doc).to include(:first_name, :last_name, :dob, :state)
     end
   end
 


### PR DESCRIPTION
Adding modifications to LN TrueID to assure the correct pii is returned for the rest of the verification process to proceed as expected.