### PR TITLE
Gracefully handle "undefined method dig" (LG-4171)

### DIFF
--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -49,7 +49,12 @@ module IdentityDocAuth
 
       def parsed_yaml_from_uploaded_file
         @parsed_yaml_from_uploaded_file ||= begin
-          YAML.safe_load(uploaded_file)
+          data = YAML.safe_load(uploaded_file)
+          if data.kind_of?(Hash)
+            data
+          else
+            { 'friendly_error' => "YAML data should have been a hash, got #{data.class}" }
+          end
         rescue Psych::SyntaxError
           nil
         end

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/keys'
+require 'uri'
 
 module IdentityDocAuth
   module Mock
@@ -42,28 +43,49 @@ module IdentityDocAuth
       private
 
       def errors
-        error = parsed_yaml_from_uploaded_file&.dig('friendly_error')
-        return {} if error.blank?
-        { results: [error] }
-      end
-
-      def parsed_yaml_from_uploaded_file
-        @parsed_yaml_from_uploaded_file ||= begin
-          data = YAML.safe_load(uploaded_file)
-          if data.kind_of?(Hash)
-            data
-          else
-            { 'friendly_error' => "YAML data should have been a hash, got #{data.class}" }
-          end
-        rescue Psych::SyntaxError
-          nil
+        error = parsed_data_from_uploaded_file&.dig('friendly_error')
+        if error.blank?
+          {}
+        else
+          { results: [error] }
         end
       end
 
+      def parsed_data_from_uploaded_file
+        return @parsed_data_from_uploaded_file if defined?(@parsed_data_from_uploaded_file)
+
+        @parsed_data_from_uploaded_file = parse_uri || parse_yaml
+      end
+
+      def parse_uri
+        uri = URI.parse(uploaded_file.chomp)
+        if uri.scheme == 'data'
+          {}
+        else
+          { 'friendly_error' => "parsed URI, but scheme was #{uri.scheme} (expected data)" }
+        end
+      rescue URI::InvalidURIError
+        # no-op, allows falling through to YAML parseing
+      end
+
+      def parse_yaml
+        data = YAML.safe_load(uploaded_file)
+        if data.kind_of?(Hash)
+          data
+        else
+          { 'friendly_error' => "YAML data should have been a hash, got #{data.class}" }
+        end
+      rescue Psych::SyntaxError
+        {}
+      end
+
       def pii_from_doc
-        return DEFAULT_PII_FROM_DOC if parsed_yaml_from_uploaded_file.blank?
-        raw_pii = parsed_yaml_from_uploaded_file['document']
-        raw_pii&.symbolize_keys || {}
+        if parsed_data_from_uploaded_file.present?
+          raw_pii = parsed_data_from_uploaded_file['document']
+          raw_pii&.symbolize_keys || {}
+        else
+          DEFAULT_PII_FROM_DOC
+        end
       end
 
       def success?

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.3.4"
+  VERSION = "0.3.5"
 end

--- a/spec/identity_doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/identity_doc_auth/mock/result_response_builder_spec.rb
@@ -91,5 +91,24 @@ RSpec.describe IdentityDocAuth::Mock::ResultResponseBuilder do
         expect(response.pii_from_doc).to eq({})
       end
     end
+
+    context 'with a string that parses as YAML' do
+      let(:error_result_yaml) do
+        <<~YAML
+          data:image/gif;base64,R0lGODlhyAAiALM...DfD0QAADs=
+        YAML
+      end
+
+      it 'returns an error response that explains it should have been a hash' do
+        builder = described_class.new(error_result_yaml)
+
+        response = builder.call
+
+        expect(response.success?).to eq(false)
+        expect(response.errors).to eq(results: ['YAML data should have been a hash, got String'])
+        expect(response.exception).to eq(nil)
+        expect(response.pii_from_doc).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
So this doesn't address the root cause, but could hopefully give us better information to debug.

The test recreates the error we've seen when testing:

```
{
"errorMessage": "undefined method `dig' for #<String:0x0000000002c1fa28>",
"errorType": "Function<NoMethodError>",
"stackTrace": [
"/var/task/vendor/bundle/ruby/2.7.0/bundler/gems/identity-doc-auth-ac9f43820717/lib/identity_doc_auth/mock/result_response_builder.rb:45:in `errors'",
```

