### PR TITLE
Skip reporting error code 440

### DIFF
--- a/lib/identity_doc_auth/acuant/request.rb
+++ b/lib/identity_doc_auth/acuant/request.rb
@@ -2,7 +2,7 @@ module IdentityDocAuth
   module Acuant
     # https://documentation.help/AssureID-Connect/Error%20Codes.html
     # 438 and 439 are frequent errors that we do not want to be notified of
-    IGNORED_ERROR_CODES = Set[438, 439]
+    IGNORED_ERROR_CODES = Set[438, 439, 440]
 
     class Request
       attr_reader :config


### PR DESCRIPTION
https://documentation.help/AssureID-Connect/Error%20Codes.html

| Status Code | Summary | Description |
--------------|-----------|---------
| 440 | Document image size is outside of the acceptable range. | The width and/or height of the document image must not be less than 100 pixels. |


