### PR TITLE
Use RedactedStruct for config

### DIFF
--- a/identity-doc-auth.gemspec
+++ b/identity-doc-auth.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('faraday')
   spec.add_dependency('activesupport')
+  spec.add_dependency('redacted_struct', '>= 1.0.0')
 end

--- a/lib/identity_doc_auth/acuant/config.rb
+++ b/lib/identity_doc_auth/acuant/config.rb
@@ -1,10 +1,12 @@
+require 'redacted_struct'
+
 module IdentityDocAuth
   module Acuant
     # @!attribute [rw] exception_notifier
     #   @return [Proc] should be a proc that accepts an Exception and an optional context hash
     #   @example
     #      config.exception_notifier.call(RuntimeError.new("oh no"), attempt_count: 1)
-    Config = Struct.new(
+    Config = RedactedStruct.new(
       :assure_id_password,
       :assure_id_subscription_id,
       :assure_id_url,
@@ -14,6 +16,13 @@ module IdentityDocAuth
       :timeout,
       :exception_notifier,
       keyword_init: true,
+      allowed_members: [
+        :assure_id_subscription_id,
+        :assure_id_url,
+        :facial_match_url,
+        :passlive_url,
+        :timeout,
+      ]
     )
   end
 end

--- a/lib/identity_doc_auth/lexis_nexis/config.rb
+++ b/lib/identity_doc_auth/lexis_nexis/config.rb
@@ -1,10 +1,12 @@
+require 'redacted_struct'
+
 module IdentityDocAuth
   module LexisNexis
     # @!attribute [rw] exception_notifier
     #   @return [Proc] should be a proc that accepts an Exception and an optional context hash
     #   @example
     #      config.exception_notifier.call(RuntimeError.new("oh no"), attempt_count: 1)
-    Config = Struct.new(
+    Config = RedactedStruct.new(
       :account_id,
       :base_url, # required
       :request_mode,
@@ -17,6 +19,16 @@ module IdentityDocAuth
       :exception_notifier, # optional
       :locale, # required
       keyword_init: true,
+      allowed_members: [
+        :account_id,
+        :base_url,
+        :request_mode,
+        :trueid_liveness_workflow,
+        :trueid_noliveness_workflow,
+        :timeout,
+        :exception_notifier,
+        :locale,
+      ],
     ) do
       def validate!
         raise 'config missing base_url' if !base_url

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
**Why**: To minimize the chances we accidentally log sensitive credentials