### PR TITLE
add Physical Document Presence error

### DIFF
--- a/lib/identity_doc_auth/error_generator.rb
+++ b/lib/identity_doc_auth/error_generator.rb
@@ -45,6 +45,7 @@ module IdentityDocAuth
       'Issue Date Valid': { type: ID, msg_key: Errors::ISSUE_DATE_CHECKS },
       'Layout Valid': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
       'Near-Infrared Response': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
+      'Physical Document Presence': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },
       'Sex Crosscheck': { type: ID, msg_key: Errors::SEX_CHECK },
       'Visible Color Response': { type: ID, msg_key: Errors::VISIBLE_COLOR_CHECK },
       'Visible Pattern': { type: ID, msg_key: Errors::ID_NOT_VERIFIED },

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
Adds error handling for a "Physical Document Presence" error, which seems to represent taking a picture of a non-physical document (as in taking a picture of a picture/screen?). `ID_NOT_VERIFIED` looked like the most appropriate error