### PR TITLE
LG-4253 New DocAuth mocking implementation

### DIFF
--- a/lib/identity_doc_auth/error_generator.rb
+++ b/lib/identity_doc_auth/error_generator.rb
@@ -99,13 +99,13 @@ module IdentityDocAuth
     # private
 
     def get_image_metric_errors(processed_image_metrics)
-      dpi_threshold = config.dpi_threshold&.to_i || 290
+      dpi_threshold = config&.dpi_threshold&.to_i || 290
       sharpness_threshold = config&.sharpness_threshold&.to_i || 40
       glare_threshold = config&.glare_threshold&.to_i || 40
 
-      front_dpi_fail, back_dpi_fail = false
-      front_sharp_fail, back_sharp_fail = false
-      front_glare_fail, back_glare_fail = false
+      front_dpi_fail, back_dpi_fail = false, false
+      front_sharp_fail, back_sharp_fail = false, false
+      front_glare_fail, back_glare_fail = false, false
 
       processed_image_metrics.each do |side, img_metrics|
         hdpi = img_metrics['HorizontalResolution']&.to_i || 0

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -116,7 +116,7 @@ module IdentityDocAuth
             transaction_reason_code: transaction_reason_code,
             doc_auth_result: doc_auth_result,
             processed_alerts: alerts,
-            alert_failure_count: alerts[:failed].length,
+            alert_failure_count: alerts[:failed]&.count.to_i,
             portrait_match_results: true_id_product[:PORTRAIT_MATCH_RESULT],
             image_metrics: parse_image_metrics,
           }

--- a/lib/identity_doc_auth/mock/config.rb
+++ b/lib/identity_doc_auth/mock/config.rb
@@ -1,0 +1,28 @@
+require 'redacted_struct'
+
+module IdentityDocAuth
+  module Mock
+    # @!attribute [rw] exception_notifier
+    #   @return [Proc] should be a proc that accepts an Exception and an optional context hash
+    #   @example
+    #      config.exception_notifier.call(RuntimeError.new("oh no"), attempt_count: 1)
+    Config = RedactedStruct.new(
+      :exception_notifier,
+      :dpi_threshold,
+      :sharpness_threshold,
+      :glare_threshold, # required
+      keyword_init: true,
+      allowed_members: [
+        :exception_notifier,
+        :dpi_threshold,
+        :sharpness_threshold,
+        :glare_threshold,
+      ],
+    ) do
+      def validate!
+        raise 'config missing base_url' if !base_url
+        raise 'config missing locale' if !locale
+      end
+    end
+  end
+end

--- a/lib/identity_doc_auth/mock/config.rb
+++ b/lib/identity_doc_auth/mock/config.rb
@@ -2,27 +2,16 @@ require 'redacted_struct'
 
 module IdentityDocAuth
   module Mock
-    # @!attribute [rw] exception_notifier
-    #   @return [Proc] should be a proc that accepts an Exception and an optional context hash
-    #   @example
-    #      config.exception_notifier.call(RuntimeError.new("oh no"), attempt_count: 1)
     Config = RedactedStruct.new(
-      :exception_notifier,
       :dpi_threshold,
       :sharpness_threshold,
       :glare_threshold, # required
       keyword_init: true,
       allowed_members: [
-        :exception_notifier,
         :dpi_threshold,
         :sharpness_threshold,
         :glare_threshold,
       ],
-    ) do
-      def validate!
-        raise 'config missing base_url' if !base_url
-        raise 'config missing locale' if !locale
-      end
-    end
+    )
   end
 end

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -1,3 +1,4 @@
+require 'identity_doc_auth/mock/config'
 require 'securerandom'
 require 'identity_doc_auth/mock/responses/create_document_response'
 
@@ -71,16 +72,22 @@ module IdentityDocAuth
         process_results(instance_id, liveness_checking_enabled, selfie_image)
       end
 
-      def get_results(instance_id:)
+      def get_results(instance_id:, liveness_enabled:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
-        ResultResponseBuilder.new(self.class.last_uploaded_back_image).call
+        config = Config.new({
+          dpi_threshold: 290,
+          sharpness_threshold: 40,
+          glare_threshold: 40,
+        })
+
+        ResultResponseBuilder.new(self.class.last_uploaded_back_image, config, liveness_enabled).call
       end
 
       private
 
       def process_results(instance_id, liveness_checking_enabled, selfie_image)
-        results_response = get_results(instance_id: instance_id)
+        results_response = get_results(instance_id: instance_id, liveness_enabled: liveness_checking_enabled)
         return results_response unless results_response.success?
 
         if liveness_checking_enabled

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -75,11 +75,11 @@ module IdentityDocAuth
       def get_results(instance_id:, liveness_enabled:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
-        config = Config.new({
+        config = Config.new(
           dpi_threshold: 290,
           sharpness_threshold: 40,
           glare_threshold: 40,
-        })
+        )
 
         ResultResponseBuilder.new(self.class.last_uploaded_back_image, config, liveness_enabled).call
       end

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -50,18 +50,21 @@ module IdentityDocAuth
         if file_data.blank?
           {}
         else
-          image_metrics = file_data&.dig('image_metrics') || {}
-          failed = file_data&.dig('failed_alerts') || []
-          passed = file_data&.dig('passed_alerts') || []
-          liveness_result = file_data&.dig('liveness_result') || ''
+          doc_auth_result = file_data.dig('doc_auth_result') || ''
+          image_metrics = file_data.dig('image_metrics') || {}
+          failed = file_data.dig('failed_alerts') || []
+          passed = file_data.dig('passed_alerts') || []
+          liveness_result = file_data.dig('liveness_result') || ''
 
-          if [image_metrics,failed, passed, liveness_result].any?(&:present?)
+          if [doc_auth_result, image_metrics, failed, passed, liveness_result].any?(&:present?)
             fake_response_info = create_response_info(
+              doc_auth_result: doc_auth_result,
               image_metrics: image_metrics&.symbolize_keys,
               failed: failed.map!(&:symbolize_keys),
               passed: passed.map!(&:symbolize_keys),
               liveness_result: liveness_result
             )
+
             ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
           else
             # general is the key for errors that come from parsing
@@ -114,16 +117,16 @@ module IdentityDocAuth
       DEFAULT_FAILED_ALERTS = [{ name: '2D Barcode Read', result: 'Failed' }].freeze
       DEFAULT_IMAGE_METRICS = {
         front: {
-          "VerticalResolution" => 300,
-          "HorizontalResolution" => 300,
-          "GlareMetric" => 50,
-          "SharpnessMetric" => 50,
+          "VerticalResolution" => 600,
+          "HorizontalResolution" => 600,
+          "GlareMetric" => 100,
+          "SharpnessMetric" => 100,
         },
         back: {
-          "VerticalResolution" => 300,
-          "HorizontalResolution" => 300,
-          "GlareMetric" => 50,
-          "SharpnessMetric" => 50,
+          "VerticalResolution" => 600,
+          "HorizontalResolution" => 600,
+          "GlareMetric" => 100,
+          "SharpnessMetric" => 100,
         }
       }.freeze
 

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -50,20 +50,21 @@ module IdentityDocAuth
         if file_data.blank?
           {}
         else
-          doc_auth_result = file_data.dig('doc_auth_result') || ''
-          image_metrics = file_data.dig('image_metrics') || {}
-          failed = file_data.dig('failed_alerts') || []
-          passed = file_data.dig('passed_alerts') || []
-          liveness_result = file_data.dig('liveness_result') || ''
+          doc_auth_result = file_data.dig('doc_auth_result')
+          image_metrics = file_data.dig('image_metrics')
+          failed = file_data.dig('failed_alerts')
+          passed = file_data.dig('passed_alerts')
+          liveness_result = file_data.dig('liveness_result')
 
           if [doc_auth_result, image_metrics, failed, passed, liveness_result].any?(&:present?)
-            fake_response_info = create_response_info(
-              doc_auth_result: doc_auth_result,
-              image_metrics: image_metrics&.symbolize_keys,
-              failed: failed.map!(&:symbolize_keys),
-              passed: passed.map!(&:symbolize_keys),
-              liveness_result: liveness_result
-            )
+            mock_args = {}
+            mock_args.merge!(doc_auth_result: doc_auth_result) if doc_auth_result.present?
+            mock_args.merge!(image_metrics: image_metrics.symbolize_keys) if image_metrics.present?
+            mock_args.merge!(failed: failed.map!(&:symbolize_keys)) if failed.present?
+            mock_args.merge!(passed: passed.map!(&:symbolize_keys)) if passed.present?
+            mock_args.merge!(liveness_result: liveness_result) if liveness_result.present?
+
+            fake_response_info = create_response_info(**mock_args)
 
             ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
           else

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -22,10 +22,12 @@ module IdentityDocAuth
         phone: nil,
       }.freeze
 
-      attr_reader :uploaded_file
+      attr_reader :uploaded_file, :config, :liveness_enabled
 
-      def initialize(uploaded_file)
+      def initialize(uploaded_file, config, liveness_enabled)
         @uploaded_file = uploaded_file.to_s
+        @config = config
+        @liveness_enabled = liveness_enabled
       end
 
       def call
@@ -43,11 +45,28 @@ module IdentityDocAuth
       private
 
       def errors
-        error = parsed_data_from_uploaded_file&.dig('friendly_error')
-        if error.blank?
+        file_data = parsed_data_from_uploaded_file
+
+        if file_data.blank?
           {}
         else
-          { results: [error] }
+          image_metrics = file_data&.dig('image_metrics') || {}
+          failed = file_data&.dig('failed_alerts') || []
+          passed = file_data&.dig('passed_alerts') || []
+          liveness_result = file_data&.dig('liveness_result') || ''
+
+          if [image_metrics,failed, passed, liveness_result].any?(&:present?)
+            fake_response_info = create_response_info(
+              image_metrics: image_metrics&.symbolize_keys,
+              failed: failed.map!(&:symbolize_keys),
+              passed: passed.map!(&:symbolize_keys),
+              liveness_result: liveness_result
+            )
+            ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
+          else
+            # general is the key for errors that come from parsing
+            file_data if file_data.include?(:general)
+          end
         end
       end
 
@@ -62,10 +81,10 @@ module IdentityDocAuth
         if uri.scheme == 'data'
           {}
         else
-          { 'friendly_error' => "parsed URI, but scheme was #{uri.scheme} (expected data)" }
+          { general: ["parsed URI, but scheme was #{uri.scheme} (expected data)"] }
         end
       rescue URI::InvalidURIError
-        # no-op, allows falling through to YAML parseing
+        # no-op, allows falling through to YAML parsing
       end
 
       def parse_yaml
@@ -73,7 +92,7 @@ module IdentityDocAuth
         if data.kind_of?(Hash)
           data
         else
-          { 'friendly_error' => "YAML data should have been a hash, got #{data.class}" }
+          { general: ["YAML data should have been a hash, got #{data.class}"] }
         end
       rescue Psych::SyntaxError
         {}
@@ -90,6 +109,44 @@ module IdentityDocAuth
 
       def success?
         errors.blank?
+      end
+
+      DEFAULT_FAILED_ALERTS = [{ name: '2D Barcode Read', result: 'Failed' }].freeze
+      DEFAULT_IMAGE_METRICS = {
+        front: {
+          "VerticalResolution" => 300,
+          "HorizontalResolution" => 300,
+          "GlareMetric" => 50,
+          "SharpnessMetric" => 50,
+        },
+        back: {
+          "VerticalResolution" => 300,
+          "HorizontalResolution" => 300,
+          "GlareMetric" => 50,
+          "SharpnessMetric" => 50,
+        }
+      }.freeze
+
+      def create_response_info(
+        doc_auth_result: 'Failed',
+        passed: [],
+        failed: DEFAULT_FAILED_ALERTS,
+        liveness_result: nil,
+        image_metrics: DEFAULT_IMAGE_METRICS
+      )
+        merged_image_metrics = DEFAULT_IMAGE_METRICS.deep_merge(image_metrics)
+        {
+          vendor: 'Mock',
+          doc_auth_result: doc_auth_result,
+          processed_alerts: {
+            passed: passed,
+            failed: failed,
+          },
+          alert_failure_count: failed&.count.to_i,
+          image_metrics: merged_image_metrics,
+          liveness_enabled: liveness_enabled,
+          portrait_match_results: { FaceMatchResult: liveness_result },
+        }
       end
     end
   end

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/identity_doc_auth/error_generator_spec.rb
+++ b/spec/identity_doc_auth/error_generator_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe IdentityDocAuth::ErrorGenerator do
         passed: passed,
         failed: failed,
       },
-      alert_failure_count: failed.length,
+      alert_failure_count: failed&.count.to_i,
       portrait_match_results: { FaceMatchResult: liveness_result },
       image_metrics: image_metrics,
     }

--- a/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       instance_id: instance_id,
       image: DocAuthImageFixtures.document_back_image,
     )
-    get_results_response = client.get_results(instance_id: instance_id)
+    get_results_response = client.get_results(instance_id: instance_id, liveness_enabled: false)
 
     selfie_response = client.post_selfie(
       instance_id: instance_id,
@@ -82,7 +82,10 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       instance_id: instance_id,
       image: yaml,
     )
-    get_results_response = client.get_results(instance_id: create_document_response.instance_id)
+    get_results_response = client.get_results(
+      instance_id: create_document_response.instance_id,
+      liveness_enabled: false
+    )
 
     expect(get_results_response.pii_from_doc).to eq(
       first_name: 'Susan',

--- a/spec/identity_doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/identity_doc_auth/mock/result_response_builder_spec.rb
@@ -158,5 +158,32 @@ RSpec.describe IdentityDocAuth::Mock::ResultResponseBuilder do
         expect(response.pii_from_doc).to eq({})
       end
     end
+
+    context 'with a yaml file containing a passing result' do
+      subject(:builder) {
+        config = IdentityDocAuth::Mock::Config.new({
+          dpi_threshold: 290,
+          sharpness_threshold: 40,
+          glare_threshold: 40,
+        })
+        described_class.new(input, config, true)
+      }
+
+      let(:input) do
+        <<~YAML
+          doc_auth_result: Passed
+          liveness_result: Fail
+        YAML
+      end
+
+      it 'returns a passed result' do
+        response = builder.call
+
+        expect(response.success?).to eq(false)
+        expect(response.errors).to eq({ selfie: [IdentityDocAuth::Errors::SELFIE_FAILURE]})
+        expect(response.exception).to eq(nil)
+        expect(response.pii_from_doc).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
DocAuthMockClient now expects an input that better reflects the how responses are actually handled. We can now make most if not all responses a user will see through the Mock and use most of the same code to produce the errors.