### PR TITLE
LG-3452 Add error handling for Acuant HTTP codes 438/439/440

### DIFF
--- a/lib/identity_doc_auth/acuant/request.rb
+++ b/lib/identity_doc_auth/acuant/request.rb
@@ -39,7 +39,6 @@ module IdentityDocAuth
 
       def fetch
         http_response = send_http_request
-        return handle_invalid_response(http_response) unless http_response.success?
 
         if http_response.success?
           handle_http_response(http_response)

--- a/lib/identity_doc_auth/acuant/request.rb
+++ b/lib/identity_doc_auth/acuant/request.rb
@@ -1,8 +1,8 @@
 module IdentityDocAuth
   module Acuant
     # https://documentation.help/AssureID-Connect/Error%20Codes.html
-    # 438 and 439 are frequent errors that we do not want to be notified of
-    IGNORED_ERROR_CODES = Set[438, 439, 440]
+    # 438, 439, and 440 are frequent errors that we do not want to be notified of
+    HANDLED_HTTP_CODES = Set[438, 439, 440]
 
     class Request
       attr_reader :config
@@ -41,7 +41,15 @@ module IdentityDocAuth
         http_response = send_http_request
         return handle_invalid_response(http_response) unless http_response.success?
 
-        handle_http_response(http_response)
+        if http_response.success?
+          handle_http_response(http_response)
+        else
+          if HANDLED_HTTP_CODES.include?(http_response.status)
+            handle_expected_http_error(http_response)
+          else
+            handle_invalid_response(http_response)
+          end
+        end
       rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         handle_connection_error(e)
       end
@@ -94,19 +102,35 @@ module IdentityDocAuth
         { open_timeout: timeout, timeout: timeout }
       end
 
-      def handle_invalid_response(http_response)
+      def create_http_exception(http_response)
         message = [
           self.class.name,
           'Unexpected HTTP response',
           http_response.status,
         ].join(' ')
-        exception = IdentityDocAuth::RequestError.new(message, http_response.status)
-        send_exception_notification(exception)
+        IdentityDocAuth::RequestError.new(message, http_response.status)
+      end
+
+      def handle_expected_http_error(http_response)
+        error = case http_response.status
+          when 438
+            Errors::IMAGE_LOAD_FAILURE
+          when 439
+            Errors::PIXEL_DEPTH_FAILURE
+          when 440
+            Errors::IMAGE_SIZE_FAILURE
+        end
+
         IdentityDocAuth::Response.new(
           success: false,
-          errors: { network: true },
-          exception: exception,
+          errors: { general: [error] },
+          exception: create_http_exception(http_response)
         )
+      end
+
+      def handle_invalid_response(http_response)
+        exception = create_http_exception(http_response)
+        handle_connection_error(exception)
       end
 
       def handle_connection_error(exception)
@@ -120,7 +144,7 @@ module IdentityDocAuth
 
       def send_exception_notification(exception, custom_params = nil)
         return if exception.is_a?(IdentityDocAuth::RequestError) &&
-          IGNORED_ERROR_CODES.include?(exception.error_code)
+          HANDLED_HTTP_CODES.include?(exception.error_code)
         config.exception_notifier&.call(exception, custom_params)
       end
     end

--- a/lib/identity_doc_auth/errors.rb
+++ b/lib/identity_doc_auth/errors.rb
@@ -1,5 +1,9 @@
 module IdentityDocAuth
   module Errors
+    # HTTP Status Codes
+    IMAGE_LOAD_FAILURE = 'image_load_failure' # 438
+    PIXEL_DEPTH_FAILURE = 'pixel_depth_failure' # 439
+    IMAGE_SIZE_FAILURE = 'image_size_failure' # 440
     # Alerts
     BARCODE_CONTENT_CHECK = 'barcode_content_check'
     BARCODE_READ_CHECK = 'barcode_read_check'

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end

--- a/spec/identity_doc_auth/acuant/request_spec.rb
+++ b/spec/identity_doc_auth/acuant/request_spec.rb
@@ -116,10 +116,6 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
 
     context 'when the request resolves with a 404 status it retries' do
       it 'calls exception_notifier each retry' do
-        # allow(subject).to receive(:handle_http_response) do |http_response|
-        #   http_response
-        # end
-
         stub_request(:get, full_url).
           with(headers: request_headers).
           to_return(

--- a/spec/identity_doc_auth/acuant/request_spec.rb
+++ b/spec/identity_doc_auth/acuant/request_spec.rb
@@ -116,9 +116,9 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
 
     context 'when the request resolves with a 404 status it retries' do
       it 'calls exception_notifier each retry' do
-        allow(subject).to receive(:handle_http_response) do |http_response|
-          http_response
-        end
+        # allow(subject).to receive(:handle_http_response) do |http_response|
+        #   http_response
+        # end
 
         stub_request(:get, full_url).
           with(headers: request_headers).
@@ -154,13 +154,7 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
     end
 
     context 'when the request resolves with a handled http error status' do
-      before do
-        allow(subject).to receive(:handle_http_response) do |http_response|
-          http_response
-        end
-      end
-
-      def shared_expects(response)
+      def expect_failed_response(response)
         expect(response.success?).to eq(false)
         expect(response.exception).to be_kind_of(IdentityDocAuth::RequestError)
         expect(response.exception.message).not_to be_empty
@@ -169,40 +163,40 @@ RSpec.describe IdentityDocAuth::Acuant::Request do
       it 'it produces a 438 error' do
         stub_request(:get, full_url).
           with(headers: request_headers).
-          to_return({ body: 'test response body', status: 438 })
+          to_return(body: 'test response body', status: 438)
 
         expect(exception_notifier).not_to receive(:call)
 
         response = subject.fetch
 
-        shared_expects(response)
-        expect(response.errors).to eq({ general: [IdentityDocAuth::Errors::IMAGE_LOAD_FAILURE] })
+        expect_failed_response(response)
+        expect(response.errors).to eq(general: [IdentityDocAuth::Errors::IMAGE_LOAD_FAILURE])
       end
 
       it 'it produces a 439 error' do
         stub_request(:get, full_url).
           with(headers: request_headers).
-          to_return({ body: 'test response body', status: 439 })
+          to_return(body: 'test response body', status: 439)
 
         expect(exception_notifier).not_to receive(:call)
 
         response = subject.fetch
 
-        shared_expects(response)
-        expect(response.errors).to eq({ general: [IdentityDocAuth::Errors::PIXEL_DEPTH_FAILURE] })
+        expect_failed_response(response)
+        expect(response.errors).to eq(general: [IdentityDocAuth::Errors::PIXEL_DEPTH_FAILURE])
       end
 
       it 'it produces a 440 error' do
         stub_request(:get, full_url).
           with(headers: request_headers).
-          to_return({ body: 'test response body', status: 440 })
+          to_return(body: 'test response body', status: 440)
 
         expect(exception_notifier).not_to receive(:call)
 
         response = subject.fetch
 
-        shared_expects(response)
-        expect(response.errors).to eq({ general: [IdentityDocAuth::Errors::IMAGE_SIZE_FAILURE] })
+        expect_failed_response(response)
+        expect(response.errors).to eq(general: [IdentityDocAuth::Errors::IMAGE_SIZE_FAILURE])
       end
     end
   end


### PR DESCRIPTION
LG-3452 Add error handling for Acuant HTTP codes 438/439/440 so that users don't see the technical difficulties error banner for known errors.