### PR TITLE
Update responses to format dates international-style (related: LG-4628)

### DIFF
--- a/lib/identity_doc_auth/acuant/pii_from_doc.rb
+++ b/lib/identity_doc_auth/acuant/pii_from_doc.rb
@@ -41,7 +41,7 @@ module IdentityDocAuth
         match = ACUANT_TIMESTAMP_FORMAT.match(date)
         return if !match || !match[:milliseconds]
 
-        Time.zone.at(match[:milliseconds].to_f / 1000).utc.strftime('%m/%d/%Y')
+        Time.zone.at(match[:milliseconds].to_f / 1000).utc.to_date.to_s
       end
 
       private

--- a/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/lib/identity_doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -101,18 +101,18 @@ module IdentityDocAuth
 
           if pii[:dob_month] && pii[:dob_day] && pii[:dob_year]
             pii[:dob] = [
+              pii.delete(:dob_year),
               pii.delete(:dob_month),
               pii.delete(:dob_day),
-              pii.delete(:dob_year),
-            ].join('/')
+            ].join('-')
           end
 
           if pii[:state_id_expiration_month] && pii[:state_id_expiration_day] && pii[:state_id_expiration_year]
             pii[:state_id_expiration] = [
+              pii.delete(:state_id_expiration_year),
               pii.delete(:state_id_expiration_month),
               pii.delete(:state_id_expiration_day),
-              pii.delete(:state_id_expiration_year),
-            ].join('/')
+            ].join('-')
           end
 
           pii

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -19,7 +19,7 @@ module IdentityDocAuth
         state_id_number: '1111111111111',
         state_id_jurisdiction: 'ND',
         state_id_type: 'drivers_license',
-        state_id_expiration: '12/31/2099',
+        state_id_expiration: '2099-12-31',
         phone: nil,
       }.freeze
 

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -93,9 +93,9 @@ module IdentityDocAuth
       end
 
       def parse_yaml
-        data = YAML.safe_load(uploaded_file)
+        data = YAML.safe_load(uploaded_file, permitted_classes: [Date])
         if data.kind_of?(Hash)
-          data
+          JSON.parse(data.to_json) # converts Dates back to strings
         else
           { general: ["YAML data should have been a hash, got #{data.class}"] }
         end

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -15,7 +15,7 @@ module IdentityDocAuth
         city: 'GREAT FALLS',
         state: 'MT',
         zipcode: '59010',
-        dob: '10/06/1938',
+        dob: '1938-10-06',
         state_id_number: '1111111111111',
         state_id_jurisdiction: 'ND',
         state_id_type: 'drivers_license',

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.9.3"
+  VERSION = "0.10.0"
 end

--- a/spec/identity_doc_auth/acuant/pii_from_doc_spec.rb
+++ b/spec/identity_doc_auth/acuant/pii_from_doc_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe IdentityDocAuth::Acuant::PiiFromDoc do
         city: 'BISMARCK',
         state: 'ND',
         zipcode: '58501',
-        dob: '04/01/1984',
-        state_id_expiration: '10/24/2022',
+        dob: '1984-04-01',
+        state_id_expiration: '2022-10-24',
         state_id_number: 'DOE-84-1165',
         state_id_jurisdiction: 'ND',
         state_id_type: 'drivers_license',
@@ -27,11 +27,11 @@ RSpec.describe IdentityDocAuth::Acuant::PiiFromDoc do
 
   describe '#convert_date' do
     it 'parses and formats a date from the Acuant format' do
-      expect(pii_from_doc.convert_date('/Date(449625600000)/')).to eq('04/01/1984')
+      expect(pii_from_doc.convert_date('/Date(449625600000)/')).to eq('1984-04-01')
     end
 
     it 'parses and formats negative numbers' do
-      expect(pii_from_doc.convert_date('/Date(-985824000000)/')).to eq('10/06/1938')
+      expect(pii_from_doc.convert_date('/Date(-985824000000)/')).to eq('1938-10-06')
     end
 
     it 'is nil for a bad format' do

--- a/spec/identity_doc_auth/acuant/responses/get_results_response_spec.rb
+++ b/spec/identity_doc_auth/acuant/responses/get_results_response_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe IdentityDocAuth::Acuant::Responses::GetResultsResponse do
         city: 'BISMARCK',
         state: 'ND',
         zipcode: '58501',
-        dob: '04/01/1984',
-        state_id_expiration: '10/24/2022',
+        dob: '1984-04-01',
+        state_id_expiration: '2022-10-24',
         state_id_number: 'DOE-84-1165',
         state_id_jurisdiction: 'ND',
         state_id_type: 'drivers_license',
@@ -124,7 +124,7 @@ RSpec.describe IdentityDocAuth::Acuant::Responses::GetResultsResponse do
         expect(response.pii_from_doc).to include(
           first_name: "FAKEY",
           last_name: "MCFAKERSON",
-          state_id_expiration: "01/14/2021",
+          state_id_expiration: "2021-01-14",
         )
       end
     end

--- a/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe IdentityDocAuth::LexisNexis::Responses::TrueIdResponse do
       minimum_expected_hash = {
         first_name: 'DAVID',
         last_name: 'SAMPLE',
-        dob: '10/13/1986',
+        dob: '1986-10-13',
         state: 'MD',
       }
 
       expect(response.pii_from_doc).to include(minimum_expected_hash)
     end
     it 'includes expiration' do
-      expect(response.pii_from_doc).to include(state_id_expiration: '10/15/2099')
+      expect(response.pii_from_doc).to include(state_id_expiration: '2099-10-15')
     end
   end
 

--- a/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       state_id_number: '1111111111111',
       state_id_jurisdiction: 'ND',
       state_id_type: 'drivers_license',
-      state_id_expiration: '12/31/2099',
+      state_id_expiration: '2099-12-31',
       phone: nil,
     )
 

--- a/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       city: 'GREAT FALLS',
       state: 'MT',
       zipcode: '59010',
-      dob: '10/06/1938',
+      dob: '1938-10-06',
       state_id_number: '1111111111111',
       state_id_jurisdiction: 'ND',
       state_id_type: 'drivers_license',
@@ -67,7 +67,7 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
         city: Bayside
         state: NY
         zipcode: '11364'
-        dob: 10/06/1938
+        dob: 1938-10-06
         state_id_number: '111111111'
         state_id_jurisdiction: ND
         state_id_type: drivers_license
@@ -97,7 +97,7 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       city: 'Bayside',
       state: 'NY',
       zipcode: '11364',
-      dob: '10/06/1938',
+      dob: '1938-10-06',
       state_id_number: '111111111',
       state_id_jurisdiction: 'ND',
       state_id_type: 'drivers_license',

--- a/spec/identity_doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/identity_doc_auth/mock/result_response_builder_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe IdentityDocAuth::Mock::ResultResponseBuilder do
             city: Bayside
             state: NY
             zipcode: '11364'
-            dob: 10/06/1938
+            dob: 1938-10-06
             state_id_number: '111111111'
             state_id_jurisdiction: ND
             state_id_type: drivers_license
@@ -59,7 +59,7 @@ RSpec.describe IdentityDocAuth::Mock::ResultResponseBuilder do
           city: 'Bayside',
           state: 'NY',
           zipcode: '11364',
-          dob: '10/06/1938',
+          dob: '1938-10-06',
           state_id_number: '111111111',
           state_id_jurisdiction: 'ND',
           state_id_type: 'drivers_license',


### PR DESCRIPTION
Moving to the international date format (`1970-12-31`) from the american date format (`12/31/1970`)

IDP update coming shortly, is also related to https://github.com/18F/identity-idp/pull/5157