### PR TITLE
Update mock proofer to be backwards compatible with american dates

### DIFF
--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -95,7 +95,7 @@ module IdentityDocAuth
       def parse_yaml
         data = YAML.safe_load(uploaded_file, permitted_classes: [Date])
         if data.kind_of?(Hash)
-          if (m = data.dig('document', 'dob')&.match(%r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}))
+          if (m = data.dig('document', 'dob').to_s.match(%r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}))
             data['document']['dob'] = Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
           end
 

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -95,6 +95,10 @@ module IdentityDocAuth
       def parse_yaml
         data = YAML.safe_load(uploaded_file, permitted_classes: [Date])
         if data.kind_of?(Hash)
+          if (m = data.dig('document', 'dob')&.match(%r{(?<month>\d{1,2})/(?<day>\d{1,2})/(?<year>\d{4})}))
+            data['document']['dob'] = Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
+          end
+
           JSON.parse(data.to_json) # converts Dates back to strings
         else
           { general: ["YAML data should have been a hash, got #{data.class}"] }

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/spec/identity_doc_auth/mock/result_response_builder_spec.rb
+++ b/spec/identity_doc_auth/mock/result_response_builder_spec.rb
@@ -67,6 +67,35 @@ RSpec.describe IdentityDocAuth::Mock::ResultResponseBuilder do
       end
     end
 
+    context 'with a yaml file containing PII and an american-style date' do
+      let(:input) do
+        <<~YAML
+          document:
+            first_name: Susan
+            last_name: Smith
+            middle_name: Q
+            address1: 1 Microsoft Way
+            address2: Apt 3
+            city: Bayside
+            state: NY
+            zipcode: '11364'
+            dob: 10/06/1938
+            state_id_number: '111111111'
+            state_id_jurisdiction: ND
+            state_id_type: drivers_license
+        YAML
+      end
+
+      it 'returns a result with that PII' do
+        response = builder.call
+
+        expect(response.success?).to eq(true)
+        expect(response.errors).to eq({})
+        expect(response.exception).to eq(nil)
+        expect(response.pii_from_doc).to include(dob: '1938-10-06')
+      end
+    end
+
     context 'with a yaml file containing a failed alert' do
       let(:input) do
         <<~YAML


### PR DESCRIPTION
Need this for https://github.com/18F/identity-idp/pull/5167