### PR TITLE
Turn unknown alerts into warnings, not exceptions (LG-4799)

### DIFF
--- a/lib/identity_doc_auth/acuant/config.rb
+++ b/lib/identity_doc_auth/acuant/config.rb
@@ -18,6 +18,7 @@ module IdentityDocAuth
       :sharpness_threshold,
       :glare_threshold,
       :exception_notifier,
+      :warn_notifier,
       keyword_init: true,
       allowed_members: [
         :assure_id_subscription_id,

--- a/lib/identity_doc_auth/lexis_nexis/config.rb
+++ b/lib/identity_doc_auth/lexis_nexis/config.rb
@@ -17,6 +17,7 @@ module IdentityDocAuth
       :trueid_username,
       :timeout, # optional
       :exception_notifier, # optional
+      :warn_notifier, # optional
       :locale,
       :dpi_threshold,
       :sharpness_threshold,

--- a/lib/identity_doc_auth/mock/config.rb
+++ b/lib/identity_doc_auth/mock/config.rb
@@ -6,6 +6,7 @@ module IdentityDocAuth
       :dpi_threshold,
       :sharpness_threshold,
       :glare_threshold, # required
+      :warn_notifier,
       keyword_init: true,
       allowed_members: [
         :dpi_threshold,

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -8,8 +8,8 @@ module IdentityDocAuth
     class DocAuthMockClient
       attr_reader :config
 
-      def initialize(config = nil)
-        @config = config || Config.new
+      def initialize(**config_keywords)
+        @config = Config.new(**config_keywords)
       end
 
       class << self

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -8,6 +8,10 @@ module IdentityDocAuth
     class DocAuthMockClient
       attr_reader :config
 
+      def initialize(config = nil)
+        @config = config || Config.new
+      end
+
       class << self
         attr_reader :response_mocks
         attr_accessor :last_uploaded_front_image
@@ -75,13 +79,17 @@ module IdentityDocAuth
       def get_results(instance_id:, liveness_enabled:)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
-        config = Config.new(
-          dpi_threshold: 290,
-          sharpness_threshold: 40,
-          glare_threshold: 40,
-        )
+        overriden_config = config.dup.tap do |c|
+          c.dpi_threshold = 290
+          c.sharpness_threshold = 40
+          c.glare_threshold = 40
+        end
 
-        ResultResponseBuilder.new(self.class.last_uploaded_back_image, config, liveness_enabled).call
+        ResultResponseBuilder.new(
+          self.class.last_uploaded_back_image,
+          overriden_config,
+          liveness_enabled,
+        ).call
       end
 
       private

--- a/lib/identity_doc_auth/mock/result_response_builder.rb
+++ b/lib/identity_doc_auth/mock/result_response_builder.rb
@@ -46,31 +46,33 @@ module IdentityDocAuth
       private
 
       def errors
-        file_data = parsed_data_from_uploaded_file
+        @errors ||= begin
+          file_data = parsed_data_from_uploaded_file
 
-        if file_data.blank?
-          {}
-        else
-          doc_auth_result = file_data.dig('doc_auth_result')
-          image_metrics = file_data.dig('image_metrics')
-          failed = file_data.dig('failed_alerts')
-          passed = file_data.dig('passed_alerts')
-          liveness_result = file_data.dig('liveness_result')
-
-          if [doc_auth_result, image_metrics, failed, passed, liveness_result].any?(&:present?)
-            mock_args = {}
-            mock_args.merge!(doc_auth_result: doc_auth_result) if doc_auth_result.present?
-            mock_args.merge!(image_metrics: image_metrics.symbolize_keys) if image_metrics.present?
-            mock_args.merge!(failed: failed.map!(&:symbolize_keys)) if failed.present?
-            mock_args.merge!(passed: passed.map!(&:symbolize_keys)) if passed.present?
-            mock_args.merge!(liveness_result: liveness_result) if liveness_result.present?
-
-            fake_response_info = create_response_info(**mock_args)
-
-            ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
+          if file_data.blank?
+            {}
           else
-            # general is the key for errors that come from parsing
-            file_data if file_data.include?(:general)
+            doc_auth_result = file_data.dig('doc_auth_result')
+            image_metrics = file_data.dig('image_metrics')
+            failed = file_data.dig('failed_alerts')
+            passed = file_data.dig('passed_alerts')
+            liveness_result = file_data.dig('liveness_result')
+
+            if [doc_auth_result, image_metrics, failed, passed, liveness_result].any?(&:present?)
+              mock_args = {}
+              mock_args.merge!(doc_auth_result: doc_auth_result) if doc_auth_result.present?
+              mock_args.merge!(image_metrics: image_metrics.symbolize_keys) if image_metrics.present?
+              mock_args.merge!(failed: failed.map!(&:symbolize_keys)) if failed.present?
+              mock_args.merge!(passed: passed.map!(&:symbolize_keys)) if passed.present?
+              mock_args.merge!(liveness_result: liveness_result) if liveness_result.present?
+
+              fake_response_info = create_response_info(**mock_args)
+
+              ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
+            else
+              # general is the key for errors that come from parsing
+              file_data if file_data.include?(:general)
+            end
           end
         end
       end

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 end

--- a/spec/identity_doc_auth/error_generator_spec.rb
+++ b/spec/identity_doc_auth/error_generator_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 RSpec.describe IdentityDocAuth::ErrorGenerator do
 
-  let(:exception_notifier) { instance_double('Proc') }
+  let(:warn_notifier) { instance_double('Proc') }
 
   let(:config) do
     IdentityDocAuth::LexisNexis::Config.new(
-      exception_notifier: exception_notifier,
+      warn_notifier: warn_notifier,
     )
   end
 
@@ -110,8 +110,8 @@ RSpec.describe IdentityDocAuth::ErrorGenerator do
         failed: [{ name: 'Not a known alert', result: 'Failed' }]
       )
 
-      expect(exception_notifier).to receive(:call).
-        with(anything, hash_including(:response_info), true).twice
+      expect(warn_notifier).to receive(:call).
+        with(hash_including(:response_info, :message)).twice
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
@@ -128,8 +128,8 @@ RSpec.describe IdentityDocAuth::ErrorGenerator do
         ]
       )
 
-      expect(exception_notifier).to receive(:call).
-        with(anything, hash_including(:response_info), true).once
+      expect(warn_notifier).to receive(:call).
+        with(hash_including(:response_info, :message, :unknown_alerts)).once
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 
@@ -144,8 +144,8 @@ RSpec.describe IdentityDocAuth::ErrorGenerator do
         failed: [{ name: 'Birth Date Crosscheck', result: 'Failed' }],
       )
 
-      expect(exception_notifier).to receive(:call).
-        with(anything, hash_including(:response_info), true).once
+      expect(warn_notifier).to receive(:call).
+        with(hash_including(:response_info, :message, :unknown_alerts)).once
 
       output = described_class.new(config).generate_doc_auth_errors(error_info)
 


### PR DESCRIPTION
Next step, will be adding a `warn_notifier` in the IDP and hooking it up to the `events.log` analytics