### PR TITLE
LG-4796: Set Acuant cropping mode by argument

### DIFF
--- a/lib/identity_doc_auth.rb
+++ b/lib/identity_doc_auth.rb
@@ -2,6 +2,7 @@ require "identity_doc_auth/acuant/acuant_client"
 require "identity_doc_auth/lexis_nexis/lexis_nexis_client"
 require "identity_doc_auth/mock/doc_auth_mock_client"
 require "identity_doc_auth/mock/result_response_builder"
+require 'identity_doc_auth/cropping_modes'
 require "identity_doc_auth/error_generator"
 require "identity_doc_auth/errors"
 require "identity_doc_auth/request_error"

--- a/lib/identity_doc_auth/acuant/acuant_client.rb
+++ b/lib/identity_doc_auth/acuant/acuant_client.rb
@@ -16,9 +16,7 @@ module IdentityDocAuth
       end
 
       def create_document(cropping_mode:)
-        request = Requests::CreateDocumentRequest.new(config: config)
-        request.cropping_mode = cropping_mode
-        request.fetch
+        Requests::CreateDocumentRequest.new(config: config, cropping_mode: cropping_mode).fetch
       end
 
       def post_front_image(image:, instance_id:)

--- a/lib/identity_doc_auth/acuant/acuant_client.rb
+++ b/lib/identity_doc_auth/acuant/acuant_client.rb
@@ -15,8 +15,10 @@ module IdentityDocAuth
         @config = Config.new(**config_keywords)
       end
 
-      def create_document
-        Requests::CreateDocumentRequest.new(config: config).fetch
+      def create_document(cropping_mode:)
+        request = Requests::CreateDocumentRequest.new(config: config)
+        request.cropping_mode = cropping_mode
+        request.fetch
       end
 
       def post_front_image(image:, instance_id:)
@@ -58,8 +60,14 @@ module IdentityDocAuth
         Requests::GetResultsRequest.new(config: config, instance_id: instance_id).fetch
       end
 
-      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil)
-        document_response = create_document
+      def post_images(
+        front_image:,
+        back_image:,
+        selfie_image:,
+        cropping_mode:,
+        liveness_checking_enabled: nil
+      )
+        document_response = create_document(cropping_mode: cropping_mode)
         return document_response unless document_response.success?
 
         instance_id = document_response.instance_id

--- a/lib/identity_doc_auth/acuant/acuant_client.rb
+++ b/lib/identity_doc_auth/acuant/acuant_client.rb
@@ -15,6 +15,7 @@ module IdentityDocAuth
         @config = Config.new(**config_keywords)
       end
 
+      # @see IdentityDocAuth::CroppingModes
       def create_document(cropping_mode:)
         Requests::CreateDocumentRequest.new(config: config, cropping_mode: cropping_mode).fetch
       end

--- a/lib/identity_doc_auth/acuant/acuant_client.rb
+++ b/lib/identity_doc_auth/acuant/acuant_client.rb
@@ -17,6 +17,10 @@ module IdentityDocAuth
 
       # @see IdentityDocAuth::CroppingModes
       def create_document(cropping_mode:)
+        if !CroppingModes::ALL.include?(cropping_mode)
+          raise "unknown cropping_mode=#{cropping_mode}"
+        end
+
         Requests::CreateDocumentRequest.new(config: config, cropping_mode: cropping_mode).fetch
       end
 

--- a/lib/identity_doc_auth/acuant/requests/create_document_request.rb
+++ b/lib/identity_doc_auth/acuant/requests/create_document_request.rb
@@ -8,6 +8,7 @@ module IdentityDocAuth
         def initialize(config:, cropping_mode:)
           super(config: config)
 
+          # @see IdentityDocAuth::CroppingModes
           @cropping_mode = cropping_mode
         end
 

--- a/lib/identity_doc_auth/acuant/requests/create_document_request.rb
+++ b/lib/identity_doc_auth/acuant/requests/create_document_request.rb
@@ -5,6 +5,8 @@ module IdentityDocAuth
   module Acuant
     module Requests
       class CreateDocumentRequest < IdentityDocAuth::Acuant::Request
+        attr_accessor :cropping_mode
+
         def path
           '/AssureIDService/Document/Instance'
         end
@@ -28,7 +30,7 @@ module IdentityDocAuth
               },
             },
             ImageCroppingExpectedSize: '1',
-            ImageCroppingMode: '1',
+            ImageCroppingMode: cropping_mode,
             ManualDocumentType: nil,
             ProcessMode: 0,
             SubscriptionId: config.assure_id_subscription_id,

--- a/lib/identity_doc_auth/acuant/requests/create_document_request.rb
+++ b/lib/identity_doc_auth/acuant/requests/create_document_request.rb
@@ -5,7 +5,11 @@ module IdentityDocAuth
   module Acuant
     module Requests
       class CreateDocumentRequest < IdentityDocAuth::Acuant::Request
-        attr_accessor :cropping_mode
+        def initialize(config:, cropping_mode:)
+          super(config: config)
+
+          @cropping_mode = cropping_mode
+        end
 
         def path
           '/AssureIDService/Document/Instance'
@@ -30,7 +34,7 @@ module IdentityDocAuth
               },
             },
             ImageCroppingExpectedSize: '1',
-            ImageCroppingMode: cropping_mode,
+            ImageCroppingMode: @cropping_mode,
             ManualDocumentType: nil,
             ProcessMode: 0,
             SubscriptionId: config.assure_id_subscription_id,

--- a/lib/identity_doc_auth/cropping_modes.rb
+++ b/lib/identity_doc_auth/cropping_modes.rb
@@ -6,5 +6,11 @@ module IdentityDocAuth
     AUTOMATIC = '1'
     # Cropping is always performed.
     ALWAYS = '3'
+
+    ALL = [
+      NONE,
+      AUTOMATIC,
+      ALWAYS,
+    ].freeze
   end
 end

--- a/lib/identity_doc_auth/cropping_modes.rb
+++ b/lib/identity_doc_auth/cropping_modes.rb
@@ -1,10 +1,10 @@
 module IdentityDocAuth
   module CroppingModes
     # No cropping is performed (default).
-    NONE = 0
+    NONE = '0'
     # Automatically determine whether cropping is required. Not recommended.
-    AUTOMATIC = 1
+    AUTOMATIC = '1'
     # Cropping is always performed.
-    ALWAYS = 3
+    ALWAYS = '3'
   end
 end

--- a/lib/identity_doc_auth/cropping_modes.rb
+++ b/lib/identity_doc_auth/cropping_modes.rb
@@ -1,0 +1,10 @@
+module IdentityDocAuth
+  module CroppingModes
+    # No cropping is performed (default).
+    NONE = 0
+    # Automatically determine whether cropping is required. Not recommended.
+    AUTOMATIC = 1
+    # Cropping is always performed.
+    ALWAYS = 3
+  end
+end

--- a/lib/identity_doc_auth/cropping_modes.rb
+++ b/lib/identity_doc_auth/cropping_modes.rb
@@ -1,11 +1,11 @@
 module IdentityDocAuth
   module CroppingModes
     # No cropping is performed (default).
-    NONE = '0'
+    NONE = '0'.freeze
     # Automatically determine whether cropping is required. Not recommended.
-    AUTOMATIC = '1'
+    AUTOMATIC = '1'.freeze
     # Cropping is always performed.
-    ALWAYS = '3'
+    ALWAYS = '3'.freeze
 
     ALL = [
       NONE,

--- a/lib/identity_doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/lib/identity_doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -34,7 +34,13 @@ module IdentityDocAuth
         raise NotImplementedError
       end
 
-      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil, **)
+      def post_images(
+        front_image:,
+        back_image:,
+        selfie_image:,
+        liveness_checking_enabled: nil,
+        cropping_mode: nil
+      )
         Requests::TrueIdRequest.new(
           config: config,
           front_image: front_image,

--- a/lib/identity_doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/lib/identity_doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -34,7 +34,7 @@ module IdentityDocAuth
         raise NotImplementedError
       end
 
-      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil)
+      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil, **)
         Requests::TrueIdRequest.new(
           config: config,
           front_image: front_image,

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -59,7 +59,7 @@ module IdentityDocAuth
         IdentityDocAuth::Response.new(success: true)
       end
 
-      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil)
+      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil, **)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
         document_response = create_document

--- a/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
+++ b/lib/identity_doc_auth/mock/doc_auth_mock_client.rb
@@ -59,7 +59,13 @@ module IdentityDocAuth
         IdentityDocAuth::Response.new(success: true)
       end
 
-      def post_images(front_image:, back_image:, selfie_image:, liveness_checking_enabled: nil, **)
+      def post_images(
+        front_image:,
+        back_image:,
+        selfie_image:,
+        liveness_checking_enabled: nil,
+        cropping_mode: nil
+      )
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
         document_response = create_document

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end

--- a/spec/identity_doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/identity_doc_auth/acuant/acuant_client_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
       expect(result.success?).to eq(true)
       expect(result.instance_id).to eq('this-is-a-test-instance-id') # instance ID from fixture
     end
+
+    context 'invalid cropping mode' do
+      let(:cropping_mode) { 'invalid' }
+
+      it 'raises an error' do
+        message = 'unknown cropping_mode=invalid'
+        expect { subject.create_document(cropping_mode: cropping_mode) }.to raise_error(message)
+      end
+    end
   end
 
   describe '#post_front_image' do

--- a/spec/identity_doc_auth/acuant/requests/create_document_request_spec.rb
+++ b/spec/identity_doc_auth/acuant/requests/create_document_request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::CreateDocumentRequest do
   describe '#fetch' do
     let(:assure_id_url) { 'https://acuant.assureid.example.com' }
     let(:assure_id_subscription_id) { '1234567' }
+    let(:cropping_mode) { IdentityDocAuth::CroppingModes::NONE }
 
     let(:url) { URI.join(assure_id_url, '/AssureIDService/Document/Instance') }
     let(:request_body) do
@@ -21,7 +22,7 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::CreateDocumentRequest do
           },
         },
         ImageCroppingExpectedSize: '1',
-        ImageCroppingMode: '1',
+        ImageCroppingMode: cropping_mode,
         ManualDocumentType: nil,
         ProcessMode: 0,
         SubscriptionId: assure_id_subscription_id,
@@ -45,7 +46,9 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::CreateDocumentRequest do
         body: response_body,
       )
 
-      response = described_class.new(config: config).fetch
+      request = described_class.new(config: config)
+      request.cropping_mode = cropping_mode
+      response = request.fetch
 
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})

--- a/spec/identity_doc_auth/acuant/requests/create_document_request_spec.rb
+++ b/spec/identity_doc_auth/acuant/requests/create_document_request_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe IdentityDocAuth::Acuant::Requests::CreateDocumentRequest do
         body: response_body,
       )
 
-      request = described_class.new(config: config)
-      request.cropping_mode = cropping_mode
-      response = request.fetch
+      response = described_class.new(config: config, cropping_mode: cropping_mode).fetch
 
       expect(response.success?).to eq(true)
       expect(response.errors).to eq({})

--- a/spec/identity_doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
+++ b/spec/identity_doc_auth/lexis_nexis/lexis_nexis_client_spec.rb
@@ -126,6 +126,18 @@ RSpec.describe IdentityDocAuth::LexisNexis::LexisNexisClient do
         expect(result.success?).to eq(false)
       end
     end
+
+    it 'ignores cropping_mode argument' do
+      result = client.post_images(
+        front_image: DocAuthImageFixtures.document_front_image,
+        back_image: DocAuthImageFixtures.document_back_image,
+        selfie_image: DocAuthImageFixtures.selfie_image,
+        liveness_checking_enabled: liveness_enabled,
+        cropping_mode: IdentityDocAuth::CroppingModes::NONE,
+      )
+
+      expect(result).to be_a(IdentityDocAuth::Response)
+    end
   end
 
   context 'when the request is not successful' do

--- a/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
+++ b/spec/identity_doc_auth/mock/dock_auth_mock_client_spec.rb
@@ -136,4 +136,15 @@ RSpec.describe IdentityDocAuth::Mock::DocAuthMockClient do
       expect(post_images_response.errors).to eq(back_image: 'blurry')
     end
   end
+
+  it 'ignores cropping_mode argument' do
+    post_images_response = client.post_images(
+      front_image: DocAuthImageFixtures.document_front_image,
+      back_image: DocAuthImageFixtures.document_back_image,
+      selfie_image: nil,
+      cropping_mode: IdentityDocAuth::CroppingModes::NONE,
+    )
+
+    expect(post_images_response).to be_a(IdentityDocAuth::Response)
+  end
 end


### PR DESCRIPTION
Related: https://github.com/18F/identity-idp/pull/5219

**Why**: The "automatic" cropping mode currently used is not recommended and may return more "Unknown" results. Allow library consumers to explicitly set the cropping mode to one of "None", "Always", or "Automatic".