### PR TITLE
LG-4738: Allow Acuant extra details to be included in log result

### DIFF
--- a/lib/identity_doc_auth/acuant/responses/get_results_response.rb
+++ b/lib/identity_doc_auth/acuant/responses/get_results_response.rb
@@ -17,29 +17,8 @@ module IdentityDocAuth
           super(
             success: successful_result?,
             errors: generate_errors,
-            extra: {
-              result: result_code.name,
-              billed: result_code.billed,
-              processed_alerts: processed_alerts,
-              alert_failure_count: processed_alerts[:failed]&.count.to_i,
-              image_metrics: processed_image_metrics,
-              raw_alerts: raw_alerts,
-              raw_regions: raw_regions,
-            }
+            extra: response_info,
           )
-        end
-
-        # Explicitly override #to_h here because this method response object contains PII.
-        # This method is used to determine what from this response gets written to events.log.
-        # #to_h is defined on the super class and should not include any parts of the response that
-        # contain PII. This method is here as a safeguard in case that changes.
-        def to_h
-          {
-            success: success?,
-            errors: errors,
-            exception: exception,
-            billed: result_code.billed,
-          }.merge(response_info)
         end
 
         # @return [DocAuth::Acuant::ResultCode::ResultCode]
@@ -64,6 +43,7 @@ module IdentityDocAuth
 
           {
             vendor: 'Acuant',
+            billed: result_code.billed,
             doc_auth_result: result_code.name,
             processed_alerts: alerts,
             alert_failure_count: alerts[:failed]&.count.to_i,

--- a/lib/identity_doc_auth/response.rb
+++ b/lib/identity_doc_auth/response.rb
@@ -11,13 +11,16 @@ module IdentityDocAuth
     end
 
     def merge(other)
-      Response.new(
-        success: success? && other.success?,
-        errors: errors.merge(other.errors),
-        exception: exception || other.exception,
-        extra: extra.merge(other.extra),
-        pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
-      )
+      # To maintain the subclass and avoid mutating the instance, set ivars on a clone.
+      clone = self.clone
+      clone.instance_eval do
+        @success = success? && other.success?
+        @errors = errors.merge(other.errors)
+        @exception = exception || other.exception
+        @extra = extra.merge(other.extra)
+        @pii_from_doc = pii_from_doc.merge(other.pii_from_doc)
+      end
+      clone
     end
 
     def success?

--- a/lib/identity_doc_auth/response.rb
+++ b/lib/identity_doc_auth/response.rb
@@ -11,16 +11,13 @@ module IdentityDocAuth
     end
 
     def merge(other)
-      # To maintain the subclass and avoid mutating the instance, set ivars on a clone.
-      clone = self.clone
-      clone.instance_eval do
-        @success = success? && other.success?
-        @errors = errors.merge(other.errors)
-        @exception = exception || other.exception
-        @extra = extra.merge(other.extra)
-        @pii_from_doc = pii_from_doc.merge(other.pii_from_doc)
-      end
-      clone
+      Response.new(
+        success: success? && other.success?,
+        errors: errors.merge(other.errors),
+        exception: exception || other.exception,
+        extra: extra.merge(other.extra),
+        pii_from_doc: pii_from_doc.merge(other.pii_from_doc),
+      )
     end
 
     def success?

--- a/lib/identity_doc_auth/version.rb
+++ b/lib/identity_doc_auth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IdentityDocAuth
-  VERSION = "0.13.0"
+  VERSION = "0.13.1"
 end

--- a/spec/identity_doc_auth/acuant/acuant_client_spec.rb
+++ b/spec/identity_doc_auth/acuant/acuant_client_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe IdentityDocAuth::Acuant::AcuantClient do
 
         expect(result.success?).to eq(true)
         expect(result.errors).to eq({})
-        expect(result.class).to eq(IdentityDocAuth::Response)
+        expect(result).to be_kind_of(IdentityDocAuth::Response)
         expect(get_face_stub).to have_been_requested
         expect(facial_match_stub).to have_been_requested
         expect(liveness_stub).to have_been_requested

--- a/spec/identity_doc_auth/response_spec.rb
+++ b/spec/identity_doc_auth/response_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+RSpec.describe IdentityDocAuth::Response do
+  let(:success) { true }
+  let(:errors) { {} }
+  let(:exception) { nil }
+  let(:pii_from_doc) { {} }
+  subject(:response) do
+    described_class.new(
+      success: success,
+      errors: errors,
+      exception: exception,
+      pii_from_doc: pii_from_doc,
+    )
+  end
+
+  describe '#merge' do
+    let(:other_success) { false }
+    let(:other_errors) { {} }
+    let(:other_exception) { nil }
+    let(:other_pii_from_doc) { {} }
+    let(:other) do
+      described_class.new(
+        success: other_success,
+        errors: other_errors,
+        exception: other_exception,
+        pii_from_doc: other_pii_from_doc,
+      )
+    end
+    let!(:merged) { response.merge(other) }
+
+    it 'does not mutate the original instance' do
+      expect(response.success?).to eq(true)
+    end
+
+    it 'returns merged instance' do
+      expect(merged).to be_kind_of(IdentityDocAuth::Response)
+    end
+
+    context 'subclass response' do
+      let(:response) do
+        config = IdentityDocAuth::Acuant::Config.new
+        http_response = instance_double(
+          Faraday::Response,
+          body: AcuantFixtures.get_results_response_success,
+        )
+        IdentityDocAuth::Acuant::Responses::GetResultsResponse.new(http_response, config)
+      end
+
+      it 'maintains original subclass' do
+        expect(merged).to be_kind_of(IdentityDocAuth::Acuant::Responses::GetResultsResponse)
+      end
+    end
+
+    describe 'success' do
+      context 'both failure' do
+        let(:success) { false }
+        let(:other_success) { false }
+
+        it 'results in false' do
+          expect(merged.success?).to eq(false)
+        end
+      end
+
+      context 'both success' do
+        let(:success) { true }
+        let(:other_success) { true }
+
+        it 'results in true' do
+          expect(merged.success?).to eq(true)
+        end
+      end
+
+      context 'one failure' do
+        let(:success) { true }
+        let(:other_success) { false }
+
+        it 'results in false' do
+          expect(merged.success?).to eq(false)
+        end
+      end
+    end
+
+    describe 'errors' do
+      let(:errors) { { a: 'foo error' } }
+      let(:other_errors) { { b: 'bar error' } }
+
+      it 'merges errors' do
+        expect(merged.errors).to eq(
+          a: 'foo error',
+          b: 'bar error',
+        )
+      end
+    end
+
+    describe 'exception' do
+      context 'no exception' do
+        it 'results in no exception' do
+          expect(merged.exception).to be_nil
+        end
+      end
+
+      context 'own exception' do
+        let(:exception) { StandardError.new }
+
+        it 'results in exception' do
+          expect(merged.exception).to eq(exception)
+        end
+      end
+
+      context 'other exception' do
+        let(:other_exception) { StandardError.new }
+
+        it 'results in exception' do
+          expect(merged.exception).to eq(other_exception)
+        end
+      end
+    end
+
+    describe 'pii_from_doc' do
+      let(:pii_from_doc) { { a: 'foo pii' } }
+      let(:other_pii_from_doc) { { b: 'bar pii' } }
+
+      it 'merges pii from doc' do
+        expect(merged.pii_from_doc).to eq(
+          a: 'foo pii',
+          b: 'bar pii',
+        )
+      end
+    end
+  end
+
+  describe '#to_h' do
+    context 'pii from doc present' do
+      let(:pii_from_doc) { { sensitive: 'sensitive' } }
+
+      it 'does not include pii from doc' do
+        expect(response.to_h.to_s).not_to match('sensitive')
+      end
+    end
+  end
+end

--- a/spec/identity_doc_auth/response_spec.rb
+++ b/spec/identity_doc_auth/response_spec.rb
@@ -37,21 +37,6 @@ RSpec.describe IdentityDocAuth::Response do
       expect(merged).to be_kind_of(IdentityDocAuth::Response)
     end
 
-    context 'subclass response' do
-      let(:response) do
-        config = IdentityDocAuth::Acuant::Config.new
-        http_response = instance_double(
-          Faraday::Response,
-          body: AcuantFixtures.get_results_response_success,
-        )
-        IdentityDocAuth::Acuant::Responses::GetResultsResponse.new(http_response, config)
-      end
-
-      it 'maintains original subclass' do
-        expect(merged).to be_kind_of(IdentityDocAuth::Acuant::Responses::GetResultsResponse)
-      end
-    end
-
     describe 'success' do
       context 'both failure' do
         let(:success) { false }


### PR DESCRIPTION
bd002c7: Retain response subclass in merge

**Why**: So that the expected behavior of that subclass remains intact after performing a merge

25c3eaf: Remove Acuant-specific to_h override

**Why**: For consistency across subclass implementations of the base response class. The base response class is already implemented mindful of avoiding the inclusion of PII. This also reflects an evolution from the initial implementation where it may have been expected that the base class could have been used to broadly handle any Acuant response. This also helps simplify to remove some redundancy in the Acuant implementation, where "extra" properties included in the call to `super` in the constructor were effectively ignored.

See:
- 18F/identity-idp#3849
- 18F/identity-idp#4060